### PR TITLE
Feature(MapSingleObject): Allows to map on a single object instead of collection only

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- Its must follow the pattern "<type>(<scope>): <subject>" -->
+<!--- where <type> can be feat/fix/doc/style/refactor/perf/test/chore -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Checklist
+- [ ] No duplicated code
+- [ ] No temporary code (console.log, commented code, dead code)
+- [ ] Code self-documentated (code hints, unit test names)
+- [ ] No sensitive information logged / sent
+- [ ] Error management with proper message
+- [ ] Unit tests 100% (new code, edited code, exhaustive)
+
+## Related Issue
+<!--- Closes #32 where #32 is github number issue-->

--- a/lib/morphism.js
+++ b/lib/morphism.js
@@ -1,49 +1,84 @@
 import * as _ from 'lodash';
 
-export default function Morphism(schema, items, type) {
-    let _schema = _.clone(schema);
-    let transformer = (items) => { // Low Level transformer function (without type consideration)
-        return _.chain(items)
-            .map((obj) => {
-                let transformedObject = _.mapValues(_schema, (predicate) => { // iterate on every predicate of the schema
-                    if (!_.isObject(predicate)) { // a predicate string path: [ desintation: 'source' ]
-                        return _.get(obj, predicate);
-                    }
-                    else if (_.isFunction(predicate)) { // a predicate function without a path: [ destination: (object) => {...} ]
-                        return predicate(obj, items);
-                    }
-                    else if (_.isArray(predicate)) { // a predicate array of string path => agregator: [ destination: ['source1', 'source2', 'source3'] ]
-                        return _.reduce(predicate, (delta, path) => {
-                            return _.set(delta, path, _.get(obj, path));
-                        }, {});
-                    }
-                    else { // a predicate object with a path and a function: [ destination : { path: 'source', fn:(fieldValue, items) }]
-                        let delta = _.get(obj, predicate.path);
-                        return predicate.fn(delta, items);
-                    }
-                });
-                return transformedObject;
-            });
-    };
+function transformValuesFromObject(object, schema, items){ // Low Level transformer function (without type consideration)
+    const _schema = _.clone(schema);
 
+    return _.mapValues(_schema, (predicate, targetProperty) => { // iterate on every predicate of the schema
+        if (!_.isObject(predicate)) { // a predicate string path: [ desintation: 'source' ]
+            return _.get(object, predicate);
+        }
+        else if (_.isFunction(predicate)) { // a predicate function without a path: [ destination: (object) => {...} ]
+            return predicate(object, items);
+        }
+        else if (_.isArray(predicate)) { // a predicate array of string path => agregator: [ destination: ['source1', 'source2', 'source3'] ]
+            return _.reduce(predicate, (delta, path) => {
+                return _.set(delta, path, _.get(object, path));
+            }, {});
+        }
+        else { // a predicate object with a path and a function: [ destination : { path: 'source', fn:(fieldValue, items) }]
+            let delta = _.get(object, predicate.path);
+            let result;
+            try{
+                result = predicate.fn.call(undefined, delta, object, items);
+            }catch(e){
+                e.message = `Unable to set target property [${targetProperty}].`
+                +`\n    An error occured when applying [${predicate.fn.name}] on property [${predicate.path}]`
+                +`\n    Internal error: ${e.message}`;
+                throw(e);
+            }
+
+            return result;
+        }
+    });
+}
+
+export default function Morphism(schema, items, type) {
+
+    const transformItems = (input, customizer) => {
+        if(_.isUndefined(input)){
+            return _.noop();
+        }
+        if(_.isArray(input) && input.length === 0){
+            return [];
+        }else if(_.isObject(input) && _.isEmpty(input)){
+            return {};
+        }
+        if (_.isArray(input)){
+            return input.map(obj =>  {
+                if(customizer){
+                    return customizer(transformValuesFromObject(obj, schema, input));
+                }else{
+                    return transformValuesFromObject(obj, schema, input);
+                }
+            });
+        }else{
+            const object = input;
+            if(customizer){
+                return customizer(transformValuesFromObject(object, schema, [object]));
+            }else{
+                return transformValuesFromObject(object, schema, [object]);
+            }
+        }
+
+    };
     if (items === undefined && type === undefined) {
-        return (items) => {
-            return transformer(items).value();
-        };
+        return transformItems;
     } else if (type) {
-        return (items) => {
-            const customizer = (destination, source) => {
-                if(_.isUndefined(source))
-                    return destination;
+
+        return (input) => {
+            const customizer = data => {
+                const undefinedValueCheck = (destination, source) => {
+                    if (_.isUndefined(source)) return destination;
+                };
+                return _.assignInWith(new type(), data, undefinedValueCheck);
             };
-            return transformer(items).map((o) => _.assignInWith(new type(), o, customizer)).value(); // TODO: Refactor this in a chain of responsibility pattern
+            return transformItems(input,customizer);
         };
     }
     else {
-        return transformer(items).value();
+        return transformItems(items);
     }
 }
-
 
 function factory(type, schema, items) {
     let typeFields = _.keys(new type());
@@ -52,7 +87,6 @@ function factory(type, schema, items) {
 
     return Morphism(finalSchema, items, type);
 }
-
 
 _.memoize.Cache = WeakMap;
 const _registry = _.memoize(factory);

--- a/lib/morphism.js
+++ b/lib/morphism.js
@@ -1,4 +1,10 @@
 import * as _ from 'lodash';
+
+const aggregator = (paths, object) => {
+    return _.reduce(paths, (delta, path) => {
+        return _.set(delta, path, _.get(object, path));
+    }, {});
+};
 /**
  * Low Level transformer function (without type consideration).
  * Take a plain object as input and transform its values using a specified schema.
@@ -17,15 +23,18 @@ function transformValuesFromObject(object, schema, items){
             return action.call(undefined, object, items);
         }
         else if (_.isArray(action)) { // Action<Array>: Aggregator - string paths => : [ destination: ['source1', 'source2', 'source3'] ]
-            return _.reduce(action, (delta, path) => {
-                return _.set(delta, path, _.get(object, path));
-            }, {});
+            return aggregator (action, object);
         }
         else if(_.isObject(action)){ // Action<Object>: a path and a function: [ destination : { path: 'source', fn:(fieldValue, items) }]
-            let delta = _.get(object, action.path);
+            let value;
+            if(_.isArray(action.path)){
+                value = aggregator(action.path, object);
+            }else if(_.isString(action.path)){
+                value = _.get(object, action.path);
+            }
             let result;
             try{
-                result = action.fn.call(undefined, delta, object, items);
+                result = action.fn.call(undefined, value, object, items);
             }catch(e){
                 e.message = `Unable to set target property [${targetProperty}].`
                 +`\n    An error occured when applying [${action.fn.name}] on property [${action.path}]`

--- a/lib/morphism.js
+++ b/lib/morphism.js
@@ -1,28 +1,34 @@
 import * as _ from 'lodash';
-
-function transformValuesFromObject(object, schema, items){ // Low Level transformer function (without type consideration)
+/**
+ * Low Level transformer function (without type consideration).
+ * Take a plain object as input and transform its values using a specified schema.
+ * @param  {Object} object
+ * @param  {Map<string, string> | Map<string, Function>} schema Transformation schema
+ * @param  {Array} items Items to be forwarded to Actions
+ */
+function transformValuesFromObject(object, schema, items){
     const _schema = _.clone(schema);
 
-    return _.mapValues(_schema, (predicate, targetProperty) => { // iterate on every predicate of the schema
-        if (!_.isObject(predicate)) { // a predicate string path: [ desintation: 'source' ]
-            return _.get(object, predicate);
+    return _.mapValues(_schema, (action, targetProperty) => { // iterate on every action of the schema
+        if (_.isString(action)) { // Action<String>: string path => [ target: 'source' ]
+            return _.get(object, action);
         }
-        else if (_.isFunction(predicate)) { // a predicate function without a path: [ destination: (object) => {...} ]
-            return predicate(object, items);
+        else if (_.isFunction(action)) { // Action<Function>: Free Computin - a callback called with the current object and collection [ destination: (object) => {...} ]
+            return action.call(undefined, object, items);
         }
-        else if (_.isArray(predicate)) { // a predicate array of string path => agregator: [ destination: ['source1', 'source2', 'source3'] ]
-            return _.reduce(predicate, (delta, path) => {
+        else if (_.isArray(action)) { // Action<Array>: Aggregator - string paths => : [ destination: ['source1', 'source2', 'source3'] ]
+            return _.reduce(action, (delta, path) => {
                 return _.set(delta, path, _.get(object, path));
             }, {});
         }
-        else { // a predicate object with a path and a function: [ destination : { path: 'source', fn:(fieldValue, items) }]
-            let delta = _.get(object, predicate.path);
+        else if(_.isObject(action)){ // Action<Object>: a path and a function: [ destination : { path: 'source', fn:(fieldValue, items) }]
+            let delta = _.get(object, action.path);
             let result;
             try{
-                result = predicate.fn.call(undefined, delta, object, items);
+                result = action.fn.call(undefined, delta, object, items);
             }catch(e){
                 e.message = `Unable to set target property [${targetProperty}].`
-                +`\n    An error occured when applying [${predicate.fn.name}] on property [${predicate.path}]`
+                +`\n    An error occured when applying [${action.fn.name}] on property [${action.path}]`
                 +`\n    Internal error: ${e.message}`;
                 throw(e);
             }
@@ -32,6 +38,12 @@ function transformValuesFromObject(object, schema, items){ // Low Level transfor
     });
 }
 
+/**
+ * Morphism curried function.
+ * @param  {Map<string, any>} schema
+ * @param  {} items
+ * @param  {} type
+ */
 export default function Morphism(schema, items, type) {
 
     const transformItems = (input, customizer) => {
@@ -106,7 +118,15 @@ class _Morphism {
         }
         return _registry(type, schema); // Store the result of the executed function in a WeakMap cache object
     }
-
+    /**
+     *
+     * @param   {Type} type
+     * @param   {Array|Object} data
+     * @returns {Array<type>|Object}
+     * @example
+     *
+     * let collectionOfType = Morphism.map(Type, [object1, object2, object3]);
+     */
     static map(type, data) {
         return _registry(type)(data);
     }

--- a/lib/morphism.js
+++ b/lib/morphism.js
@@ -56,13 +56,8 @@ function transformValuesFromObject(object, schema, items){
 export default function Morphism(schema, items, type) {
 
     const transformItems = customizer => input => {
-        if(_.isUndefined(input)){
-            return _.noop();
-        }
-        if(_.isArray(input) && input.length === 0){
-            return [];
-        }else if(_.isObject(input) && _.isEmpty(input)){
-            return {};
+        if(!input){
+            return input;
         }
         if (_.isArray(input)){
             return input.map(obj =>  {

--- a/lib/morphism.js
+++ b/lib/morphism.js
@@ -55,7 +55,7 @@ function transformValuesFromObject(object, schema, items){
  */
 export default function Morphism(schema, items, type) {
 
-    const transformItems = (input, customizer) => {
+    const transformItems = customizer => input => {
         if(_.isUndefined(input)){
             return _.noop();
         }
@@ -83,7 +83,7 @@ export default function Morphism(schema, items, type) {
 
     };
     if (items === undefined && type === undefined) {
-        return transformItems;
+        return transformItems(null);
     } else if (type) {
 
         return (input) => {
@@ -93,11 +93,11 @@ export default function Morphism(schema, items, type) {
                 };
                 return _.assignInWith(new type(), data, undefinedValueCheck);
             };
-            return transformItems(input,customizer);
+            return transformItems(customizer)(input);
         };
     }
     else {
-        return transformItems(items);
+        return transformItems(null)(items);
     }
 }
 
@@ -137,6 +137,12 @@ class _Morphism {
      * let collectionOfType = Morphism.map(Type, [object1, object2, object3]);
      */
     static map(type, data) {
+        if(!_Morphism.exists(type)){
+            const mapper = _Morphism.register(type);
+            if(data === undefined){
+                return mapper;
+            }
+        }
         return _registry(type)(data);
     }
 

--- a/test/morphism.spec.js
+++ b/test/morphism.spec.js
@@ -370,8 +370,7 @@ describe('Morphism', function () {
 
         it('should fallback to constructor default value and ignore function when path value is undefined', function () {
             let mock = {
-                lastname: 'user-lastname',
-
+                lastname: 'user-lastname'
             };
             let schema = {
                 type : {

--- a/test/morphism.spec.js
+++ b/test/morphism.spec.js
@@ -32,7 +32,7 @@ describe('Morphism', function () {
         this.mapUser = Morphism.register(User);
     });
 
-    describe('Structural', function () {
+    describe('Plain Objects', function () {
         it('should export Morphism function curried function', function () {
             expect(Morphism).toBeA('function');
         });
@@ -88,6 +88,37 @@ describe('Morphism', function () {
             expect(applyMapping).toThrow(TypeError);
         });
 
+        it('should allow to use a mapper as an iteratee first function', function () {
+            let mocks = [
+                {source: 'value'},
+                {source: 'value'},
+                {source: 'value'}
+            ];
+            let schema={
+                target:'source'
+            };
+            const mapper = Morphism(schema);
+            let results = mocks.map(mapper);
+            results.forEach(res => {
+                expect(res).toEqual({target: 'value'});
+            });
+        });
+
+        it('should allow to use a mapper declaration as an iteratee first function', function () {
+            let mocks = [
+                {source: 'value'},
+                {source: 'value'},
+                {source: 'value'}
+            ];
+            let schema={
+                target:'source'
+            };
+
+            let results = mocks.map(Morphism(schema));
+            results.forEach(res => {
+                expect(res).toEqual({target: 'value'});
+            });
+        });
     });
 
     describe('Mapper Instance', function () {
@@ -417,6 +448,71 @@ describe('Morphism', function () {
 
             let result = Morphism.map(User, mock);
             expect(result.type).toEqual('User');
+        });
+
+        describe('Projection', () => {
+            it('should allow to map property one to one when using `Morphism.map(Type,object)` without registration', function () {
+                let mock =  {field: 'value'};
+                class Target {
+                    constructor(field){
+                        this.field = field;
+                    }
+                }
+                const result = Morphism.map(Target, mock);
+                expect(result).toEqual(new Target('value'));
+            });
+
+            it('should allow to map property one to one when using `Morphism.map(Type,data)` without registration', function () {
+                let mocks = [
+                    {field: 'value'},
+                    {field: 'value'},
+                    {field: 'value'}
+                ];
+                class Target {
+                    constructor(field){
+                        this.field = field;
+                    }
+                }
+                const results = Morphism.map(Target, mocks);
+                results.forEach(res => {
+                    expect(res).toEqual(new Target('value'));
+                });
+            });
+
+            it('should allow to use Morphism.map as an iteratee first function', function () {
+                let mocks = [
+                    {field: 'value'},
+                    {field: 'value'},
+                    {field: 'value'}
+                ];
+                class Target {
+                    constructor(field){
+                        this.field = field;
+                    }
+                }
+                const results = mocks.map(Morphism.map(Target));
+                results.forEach(res => {
+                    expect(res).toEqual(new Target('value'));
+                });
+            });
+
+            it('should allow to use mapper from `Morphism.map(Type, undefined)` as an iteratee first function', function () {
+                let mocks = [
+                    {field: 'value'},
+                    {field: 'value'},
+                    {field: 'value'}
+                ];
+                class Target {
+                    constructor(field){
+                        this.field = field;
+                    }
+                }
+                const mapper = Morphism.map(Target);
+                const results = mocks.map(mapper);
+                results.forEach(res => {
+                    expect(res).toEqual(new Target('value'));
+                });
+            });
         });
     });
 });

--- a/test/morphism.spec.js
+++ b/test/morphism.spec.js
@@ -107,7 +107,6 @@ describe('Morphism', function () {
             let results = mapper(this.dataToCrunch);
             expect(results[0]).toEqual(desiredResult);
             expect(results[0]).toEqual(mapper(this.dataToCrunch)[0]);
-
         });
     });
 
@@ -197,9 +196,43 @@ describe('Morphism', function () {
             let results = Morphism(schema, this.dataToCrunch);
             expect(results[0]).toEqual(desiredResult);
         });
+
+        it('should return a object of aggregated values given a array of paths (nested path case)', function () {
+            let schema = {
+                user: ['firstName', 'address.city']
+            };
+
+            let desiredResult = {
+                user: {
+                    firstName: 'John',
+                    address: {
+                        city: 'New York'
+                    }
+                }
+            };
+            let results = Morphism(schema, this.dataToCrunch);
+            expect(results[0]).toEqual(desiredResult);
+        });
+
+
+        it('should provide an aggregate as a result from an array of paths when applying a function',()=>{
+            let data = {a:1 , b: { c: 2 }};
+            let rules = {
+                ac: {
+                    path: ['a','b.c'],
+                    fn: aggregate => {
+                        expect(aggregate).toEqual({ a:1, b:{ c:2 } });
+                        return aggregate;
+                    }
+                }
+            };
+            let res = Morphism(rules, data);
+
+            expect(res).toEqual({ac: { a:1, b:{ c:2 } }});
+        });
     });
 
-    describe('Flat projection', function () {
+    describe('Flattening and Projection', function () {
 
         it('should flatten data from specified path', function () {
             let schema = {


### PR DESCRIPTION
**No breaking changes. Full backward compatible with previous versions.**
### Single Object Mapping
Allows to map a single object instead of collection only. The output dimension is the same as the input dimension.
#### To map an object, or collection before
```
let source = {...};
let object = Morphism(schema, [source])[0];

// Iterate on collection and map
collection.map(item => Morphism(schema,[item])[0];
```
#### To map an object, or collection now
```
let source = {...};
let object = Morphism(schema, source);
// → {...} output is an object
```
```
let sources = [{...}, {...}];
let ouput = Morphism(schema, sources);
// → [] output is a collection
```
```
let output = Morphism.map(Type, []);
// →Type[] output is a collection of Type
```
```
let output = Morphism.map(Type, {});
// →Type{} output is a Type object
```
### Make low level and typed mappers functions iteratee first:

now it's possible to do:
#### map over a Low Level mapper (schema applied on plain objects)
```
let collection = [{...}, {...}];
let results = collection.map(Morphism(schema));
```
```
let collection = [{...}];
const mapper = Morphism(schema);
let results = collection.map(mapper);
```

#### map over a Typed mapper (schema applied on Type)
```
let collection = [{...}, {...}];
class Type {}
let mapper = Morphism.register(Type);
let results = collection.map(mapper);
```
```
let collection = [{...}, {...}];
class Type {}
let results = collection.map(Morphism.map(Type));
```
## Misc
- Add defensive programming on undefined input
- Properly rethrows Exception inside call function
- Refactoring and JsDoc
- Bunch of Unit Tests
Closes #8 